### PR TITLE
conda activate 시 환경별로 env 이름이 다른 점 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ _노트_: [깃허브의 노트북 뷰어](index.ipynb)를 사용할 수도 있�
 그다음 다음 명령을 실행합니다:
 
     $ conda env create -f environment.yml # 윈도우일 경우 environment-windows.yml
-    $ conda activate tf2
+    $ conda activate homl2 # 윈도우일 경우 conda activate tf2
     $ python -m ipykernel install --user --name=python3
 
 그다음 윈도우일 경우 다음 명령을 실행하세요:


### PR DESCRIPTION
안녕하세요.

environment.yml 에서의 name 값(homl2)과 environment-windows.yml 에서의 name 값(tf2)이 다름에따라

README.md 에서 conda activate 실행 시 각 환경별로 다른 환경 이름을 활성화해야한다는 설명에 대한 PR 입니다.

최초 의도가 환경별로 다른 conda env name 인지 아닌지가 확신이 안섭니다만 알려주시면 맞춰서 다시 수정 후 PR 올리겠습니다.

이 PR 은 README.md 의 수정본입니다.